### PR TITLE
Using Apptainer to run the MySQL server and client in the mysql image

### DIFF
--- a/_episodes/04-mysql-and-python.md
+++ b/_episodes/04-mysql-and-python.md
@@ -88,11 +88,14 @@ We need the following URL components:
 * Database Name: Name of the specific database to connect to.
 
 So, the URL structure is : `Dialect+driver://username:password@hostname:port/databaseName`
+or, if you use Apptainer and a socket file is:  `Dialect+driver://username:password@localhost/databaseName?unix_socket=filePath`
 
 And we create a engine using this db_url.
 ```python
 # Define the MySQL database connection URL
 db_url = "mysql+pymysql://root:mypassword@localhost:3306/metadata2"
+# if using Apptainer uncomment the next line to define the URL using the socket file:
+# db_url = "mysql+pymysql://root:mypassword@localhost/metadata2?unix_socket=/var/run/mysqld/mysql.sock"
 
 # Create an SQLAlchemy engine
 engine = create_engine(db_url)


### PR DESCRIPTION
Using Apptainer to run the MySQL server and client in the mysql image from Docker Hub

Added the setup for unprivileged Apptainer (no network privilege and no overlayfs).
Added also the sqlalchemy URL using the socket file for the apptainer version

This example helped me a lot: https://ponyland.science.ru.nl/ponyland/development_tips/mysql_with_apptainer/

PS I saw some pre-commit errors in files that I did not touch. I did not fix them in the PR in case it's a work in progress by someone else:
```
codespell................................................................Failed
- hook id: codespell
- exit code: 65

_episodes/10-text-based-search.md:88: docuement ==> document
_episodes/09-opensearch-queires.md:45: vitual ==> virtual, visual
_episodes/09-opensearch-queires.md:266: docuemnts ==> documents

blacken-docs.............................................................Failed
- hook id: blacken-docs
- exit code: 2

_episodes/09-opensearch-queires.md:181: code block parse error Cannot parse: 19:60: print("Total Number of successfully indexed documents: %s"  str(res[0]))
```